### PR TITLE
Update wording, add "get as base64"

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,9 @@
 <body>
 
 <header>
-<h1><a href='http://instantsprite.com'>Instant Sprite</a></h1>
+<h1><a href='http://instantsprite.com'>Instant Sprite</a>
+    <span class="desc">CSS Sprite Generator</span>
+</h1>
 <div class='links'>
 <a href='http://twitter.com/bgrins'>@bgrins</a>
 <a class='icon github' target='_blank' href='http://github.com/bgrins/InstantSprite/' title='Follow the project to be notified of changes, and discuss possible features and issues.'>Follow!</a>
@@ -29,7 +31,7 @@
 
 <div id='app'>
 <div id='intro' class='info'>
-<em>Welcome to Instant Sprite, the fastest way for you to make CSS sprites.</em><br />All the work will be done in your browser, so don't worry about sending your images over the Internet. <br />If you feel lost or want more information about CSS sprites, see <a href='articles/what-are-css-sprites/' target='_blank'>what are CSS sprites</a>. Once you are ready, follow the instructions below to get started. 
+<em>Welcome to Instant Sprite, the fastest way for to generate CSS sprites.</em><br />All the work will be done in your browser, so don't worry about sending your images over the Internet. <br />If you feel lost or want more information about generating CSS sprites, see <a href='articles/what-are-css-sprites/' target='_blank'>what are CSS sprites</a>. Once you are ready, follow the instructions below to get started. 
 </div>
 <section id='source' class='full clearfix'>
 	<div id='initialload'>Loading, please wait...<span></span></div>
@@ -73,9 +75,12 @@
 </section>
 <section>
     <header>Sprite</header>
-    <div class='help'>Right click the image to save it to your computer.  <a href='#' id='openInNewWindow' class='disabled'>Open image in a new window</a> 
-    <a href='#' id='crushImage' class='disabled'>Get Optimized Image</a>
-    .</div>
+    <div class='help'>Right click the image to save it to your computer.
+        <a href='#' id='openInNewWindow' class='disabled'>Open image in a new window</a> 
+        <a href='#' id='crushImage' class='disabled'>Get Optimized Image</a>
+        <a href='#' id='base64Image' class='disabled'>As Base64</a>
+        <textarea id='textarea-base64' style='display: none;'></textarea>
+    </div>
     <div class='content' id='result'>
     </div>
 </section>

--- a/site/scripts/instantsprite.js
+++ b/site/scripts/instantsprite.js
@@ -15,6 +15,8 @@ var elements = sprite.elements = {
 	exportCss: '#exportCss',
 	exportHtml: '#exportHtml',
 	exportImageNewWindow: '#openInNewWindow',
+	exportBase64: '#base64Image',
+	base64Box: '#textarea-base64',
 	crushImage: '#crushImage',
 	preview: '#preview',
 	result: '#result',
@@ -385,7 +387,10 @@ sprite.mergefiles = function() {
 		resultBase64 = resultCanvas.toDataURL("image/" + opts.exportAs);
 		elements.result.html("<img src='"+resultBase64+"'>");
 		elements.exportImageNewWindow.removeClass('disabled');
+		elements.exportBase64.removeClass('disabled');
+		elements.base64Box.val(resultBase64);
 		elements.crushImage.attr("href", "png.php?img=" + resultBase64);
+
 	}
 	else {
 		elements.result.html("");
@@ -438,6 +443,15 @@ sprite.init = function() {
 		}
 		return false;
 	});
+
+	elements.exportBase64.click(function() {
+		if (!$(this).hasClass("disabled")) {
+			elements.base64Box.toggle().focus().select();
+		}
+
+		return false;
+	});
+
 	elements.fileSamples.click(function() {
 		for (var i = 0; i < settings.sampleImages.length; i++) {
 			sprite.loadimage(settings.sampleImages[i].src, settings.sampleImages[i]);

--- a/site/styles/instantsprite.css
+++ b/site/styles/instantsprite.css
@@ -8,6 +8,8 @@ h1 { margin:.7em 0; font-size:2em; }
 h2 { margin:.6em 0; font-size: 1.4em;}
 h3 { margin:.8em 0; font-size: 1.1em; }
 
+h1 .desc {  font-size: 10px; display:block; font-weight: normal; }
+
 /* Helpers */
 .clearfix:after { content: "."; display: block; height: 0; clear: both; visibility: hidden; }
 .clearfix { zoom: 1; }
@@ -127,3 +129,5 @@ form { margin: 0; padding: 0; }
 #example pre.html:before { content: 'html'; display:block; font-weight:bold; } 
 #example .rundown {padding:10px 0; width:40em; margin:0 auto;}
 #example .rundown .pros, .example .rundown .cons { float: left; width: 14em; }
+
+#textarea-base64 { display: block; width: 100%; }


### PR DESCRIPTION
It's becoming more and more common to use base-64 images in CSS files, this adds a link to download the CSS sprite as base-64 instead of as an image.

Also updates some wording.
