### PR TITLE
CSS generation improvements

### DIFF
--- a/site/scripts/instantsprite.js
+++ b/site/scripts/instantsprite.js
@@ -215,22 +215,18 @@ sprite.dimensionfrequency = function() {
 		widths[canvas.width] = !widths[canvas.width] ? 1 : widths[canvas.width] + 1;
 	});
 
-	var numberOfHeights = 0,
-		mostFrequentHeight = 0,
+	var mostFrequentHeight = 0,
 		heightCount = 0;
 	for (var h in heights) {
-		numberOfHeights++;
 		if (heightCount < heights[h]) {
 			heightCount = heights[h];
 			mostFrequentHeight = parseInt(h, 10);
 		}
 	}
 
-	var numberOfWidths = 0,
-		mostFrequentWidth = 0,
+	var mostFrequentWidth = 0,
 		widthCount = 0;
 	for (var w in widths) {
-		numberOfWidths++;
 		if (widthCount < widths[w]) {
 			widthCount = widths[w];
 			mostFrequentWidth = parseInt(w, 10);
@@ -241,9 +237,7 @@ sprite.dimensionfrequency = function() {
 		mostFrequentWidth: mostFrequentWidth,
 		mostFrequentHeight: mostFrequentHeight,
 		mostFrequentWidthCount: widthCount,
-		mostFrequentHeightCount: heightCount,
-		numberOfWidths: numberOfWidths,
-		numberOfHeights: numberOfHeights
+		mostFrequentHeightCount: heightCount
 	}
 };
 
@@ -326,8 +320,6 @@ sprite.eachcanvas = function(cb) {
 sprite.mergefiles = function() {
 
 	var opts = sprite.getopts(),
-		len = sprite.getcanvases().length,
-		totalSpacing = len * opts.offset,
 		isVertical = opts.vertical,
 		isHorizontal = opts.horizontal,
 		isDiagonal = opts.diagonal,


### PR DESCRIPTION
As discussed on [Stack Overflow](http://stackoverflow.com/a/4185556/24874):
- Use default dimensions in more cases
- Drop redundant `px` suffix on zero dimensions
- Remove extra whitespace in CSS

Also a few statement termination things, accidental global leakage and removal of unused vars.

Normally I'd do all of these as separate PRs but seeing as you seemed receptive to them on SO I thought I'd just bundle them all here. You can pick commits if you like though.
